### PR TITLE
Support --inspect-brk flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var FLAGS = [
     '--debug',
     '--debug-brk',
     '--inspect',
+    '--inspect-brk',
     '--expose-gc',
     '--gc-global',
     '--es_staging',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bin-v8-flags-filter",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Filters out v8 flags for your Node.js CLIs.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
\cc @AlexanderMoskovkin 

It seems a test will require to attach a debugger to continue execution.