### PR TITLE
Add --experimental-repl-await flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ var FLAGS = [
     '--trace-deprecation',
     '--use_strict',
     '--allow-natives-syntax',
-    '--perf-basic-prof'
+    '--perf-basic-prof',
+    '--experimental-repl-await'
 ];
 
 var FLAG_PREFIXES = [


### PR DESCRIPTION
The --experimental-repl-await flag is new in node v10