### PR TITLE
Add ignore option to not filter certain flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,13 @@ const cliPath = path.join(__dirname, './cli.js'); // Path to your actual CLI fil
 v8FlagsFilter(cliPath);
 ```
 
+### API
+#### `v8FlagsFilter(path, [options])`
+ - `path` - path to CLI script.
+ - `options` - an optional object with the following optional keys:
+   - `ignore` - an array of v8 flags to ignore, i.e. to _not_ filter-out when spawning a new process.
+   - `forcedKillDelay` - a number of milliseconds after which to send a kill command to the spawned process, only after an interrupt has already been issued.  Defaults to `30000`.
+   - `useShutdownMessage` - rather than forwarding along interrupt signals to the spawned process, instead forwards a `'shutdown'` message to the spawned process.
+
 ## Author
 [Ivan Nikulin](https://github.com/inikulin) (ifaaan@gmail.com)

--- a/index.js
+++ b/index.js
@@ -29,11 +29,16 @@ var FLAG_PREFIXES = [
 
 var DEFAULT_FORCED_KILL_DELAY = 30000;
 
-function getChildArgs (cliPath) {
+function getChildArgs (cliPath, ignore) {
     var args = [cliPath];
 
     process.argv.slice(2).forEach(function (arg) {
         var flag = arg.split('=')[0];
+
+        if (ignore.indexOf(flag) > -1) {
+            args.push(arg);
+            return;
+        }
 
         if (FLAGS.indexOf(flag) > -1) {
             args.unshift(arg);
@@ -73,7 +78,8 @@ function setupSignalHandler (signal, childProcess, useShutdownMessage, forcedKil
 module.exports = function (cliPath, opts) {
     var useShutdownMessage = opts && opts.useShutdownMessage;
     var forcedKillDelay    = opts && opts.forcedKillDelay || DEFAULT_FORCED_KILL_DELAY;
-    var args               = getChildArgs(cliPath);
+    var ignore             = opts && opts.ignore || [];
+    var args               = getChildArgs(cliPath, ignore);
 
     var cliProc = spawn(process.execPath, args, { stdio: [process.stdin, process.stdout, process.stderr, useShutdownMessage ? 'ipc' : null] });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -3,6 +3,9 @@ var filter = require('../');
 
 var gracefulShutdown = process.argv.indexOf('--graceful-shutdown') > -1;
 var noIPCTest        = process.argv.indexOf('--no-ipc-test') > -1;
+var ignoreTraceGc    = process.argv.indexOf('--ignore-trace-gc') > -1;
 
-filter(path.join(__dirname, './actual-cli.js'), { useShutdownMessage: gracefulShutdown || noIPCTest });
-
+filter(path.join(__dirname, './actual-cli.js'), {
+    useShutdownMessage: gracefulShutdown || noIPCTest,
+    ignore: ignoreTraceGc && ['--trace-gc']
+});

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,24 @@ it('Should filter v8 flags', function (done) {
     });
 });
 
+it('Should use ignore option to not filter some v8 flags', function (done) {
+    var args = [
+        path.join(__dirname, './cli.js'),
+        '--hey',
+        '--allow-natives-syntax',
+        '-t=yo',
+        '--trace-gc',
+        '--ignore-trace-gc'
+    ];
+
+    execFile(process.execPath, args, function (err, stdout) {
+        assert.ok(stdout.indexOf('$$$ARGS:["--hey","-t=yo","--trace-gc","--ignore-trace-gc"]$$$') > -1);
+        assert.ok(stdout.indexOf('$$$ISSMI:true$$$') > -1);
+
+        done();
+    });
+});
+
 it('Should use shutdown message', function (done) {
     var args = [
         path.join(__dirname, './cli.js'),


### PR DESCRIPTION
This option allows the user to ignore some v8 flags.  My personal use-case is that my CLI has a `debug` command, and I do not want to filter it into a node argument.