### PR TITLE
feat: added a possibility to force args

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ var FLAGS = [
     '--use_strict',
     '--allow-natives-syntax',
     '--perf-basic-prof',
-    '--experimental-repl-await'
+    '--experimental-repl-await',
+    '--experimental-loader',
+    '--no-warnings'
 ];
 
 var FLAG_PREFIXES = [
@@ -81,6 +83,9 @@ module.exports = function (cliPath, opts) {
     var forcedKillDelay    = opts && opts.forcedKillDelay || DEFAULT_FORCED_KILL_DELAY;
     var ignore             = opts && opts.ignore || [];
     var args               = getChildArgs(cliPath, ignore);
+    
+    if (opts.forcedArgs && opts.forcedArgs.length > 0)
+        args.unshift(...opts.forcedArgs);
 
     var cliProc = spawn(process.execPath, args, { stdio: [process.stdin, process.stdout, process.stderr, useShutdownMessage ? 'ipc' : null] });
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bin-v8-flags-filter",
+  "name": "@devexpress/bin-v8-flags-filter",
   "version": "1.3.0",
   "description": "Filters out v8 flags for your Node.js CLIs.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bin-v8-flags-filter",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Filters out v8 flags for your Node.js CLIs.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
It needs to have the possibility to force some args. Because for some of the args there is no other way to define them. For example: [`--experimental-loader`](https://nodejs.org/api/cli.html#--experimental-loadermodule)